### PR TITLE
fix: added splide dom check

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -14,7 +14,9 @@ Alpine.plugin(FormsAlpinePlugin)
 window.Alpine = Alpine
 Alpine.start()
 
-new Splide('.splide').mount()
+if (document.querySelector('.splide')){
+    new Splide('.splide').mount()
+}
 
 docsearch({
     appId: 'BH4D9OD16A',


### PR DESCRIPTION
.splide element doesn't have on docs pages for this reason stop javascript runtime and doesn't work docsearch